### PR TITLE
Use `STRICT_R_HEADERS` for R 4.5.0 compatibility

### DIFF
--- a/src/survAUC_Cham_Diao.c
+++ b/src/survAUC_Cham_Diao.c
@@ -7,6 +7,8 @@
  *
  */
 
+#define STRICT_R_HEADERS
+
 #include <Rinternals.h>
 #include <Rdefines.h>
 #include <R.h>
@@ -31,13 +33,13 @@ SEXP Cham_Diao(SEXP LP, SEXP TH_TIME, SEXP TIME, SEXP EVENT, SEXP N_TIME,
 
 	N_th_times = LENGTH(TH_TIME);
 	double *surv_new;
-	surv_new = Calloc(N_th_times * ncx, double);
+	surv_new = R_Calloc(N_th_times * ncx, double);
 
 	step_eval3(surv_new, REAL(TH_TIME), REAL(VECTOR_ELT(S1a, 0)), REAL(VECTOR_ELT(S1a, 1)), N_th_times, ncx, nrx);
 	UNPROTECT(1);
 
 	double *factor1;
-	factor1 = Calloc(N_th_times, double);
+	factor1 = R_Calloc(N_th_times, double);
 
 	for (i = 0; i < N_th_times; i++)
 	{
@@ -51,7 +53,7 @@ SEXP Cham_Diao(SEXP LP, SEXP TH_TIME, SEXP TIME, SEXP EVENT, SEXP N_TIME,
 	}
 
 	double *EW;
-	EW = Calloc(N_th_times, double);
+	EW = R_Calloc(N_th_times, double);
 
 	int n_lpnew = INTEGER(N_LPNEW)[0];
 	for (i = 0; i < n_lpnew; i++)
@@ -82,9 +84,9 @@ SEXP Cham_Diao(SEXP LP, SEXP TH_TIME, SEXP TIME, SEXP EVENT, SEXP N_TIME,
 			[i] = 0.0;
 		}
 	}
-	Free(EW);
-	Free(factor1);
-	Free(surv_new);
+	R_Free(EW);
+	R_Free(factor1);
+	R_Free(surv_new);
 	PROTECT(IAUC = allocVector(REALSXP, 1));
 	if (TIME_NEW == R_NilValue)
 	{
@@ -96,9 +98,9 @@ SEXP Cham_Diao(SEXP LP, SEXP TH_TIME, SEXP TIME, SEXP EVENT, SEXP N_TIME,
 		/* Calculation of iAUC */
 		int n_new_data = INTEGER(N_TIME_NEW)[0];
 		double *f, *S, *S_new;
-		f = Calloc(N_th_times, double);
-		S_new = Calloc(n_new_data, double);
-		S = Calloc(N_th_times, double);
+		f = R_Calloc(N_th_times, double);
+		S_new = R_Calloc(n_new_data, double);
+		S = R_Calloc(N_th_times, double);
 		km_Daim(S_new, REAL(TIME_NEW), REAL(EVENT_NEW), INTEGER(N_TIME_NEW));
 		step_eval2(S, REAL(TH_TIME), S_new, REAL(TIME_NEW), N_th_times, n_new_data);
 
@@ -123,9 +125,9 @@ SEXP Cham_Diao(SEXP LP, SEXP TH_TIME, SEXP TIME, SEXP EVENT, SEXP N_TIME,
 					i_auc += REAL(AUC)[i] * (f[i]) / wT;
 			}
 		}
-		Free(f);
-		Free(S);
-		Free(S_new);
+		R_Free(f);
+		R_Free(S);
+		R_Free(S_new);
 		REAL(IAUC)
 		[0] = i_auc;
 	}

--- a/src/survAUC_SongZhou.c
+++ b/src/survAUC_SongZhou.c
@@ -7,6 +7,8 @@
  *
  */
 
+#define STRICT_R_HEADERS
+
 #include <Rinternals.h>
 #include <Rdefines.h>
 #include <R.h>
@@ -22,7 +24,7 @@ SEXP auc_SZ(SEXP THRESH, SEXP T, SEXP STIME, SEXP EVENT, SEXP N_TIME,
 	SEXP S1a, xdims, spec;
 
 	double *lp_new;
-	lp_new = Calloc(INTEGER(N_LPNEW)[0], double);
+	lp_new = R_Calloc(INTEGER(N_LPNEW)[0], double);
 	for (i = 0; i < INTEGER(N_LPNEW)[0]; i++)
 	{
 		lp_new[i] = REAL(LPNEW)[i];
@@ -35,7 +37,7 @@ SEXP auc_SZ(SEXP THRESH, SEXP T, SEXP STIME, SEXP EVENT, SEXP N_TIME,
 
 	int N_times = LENGTH(T);
 	double *surv_new;
-	surv_new = Calloc(N_times * ncx, double);
+	surv_new = R_Calloc(N_times * ncx, double);
 
 	step_eval3(surv_new, REAL(T), REAL(VECTOR_ELT(S1a, 0)), REAL(VECTOR_ELT(S1a, 1)), N_times, ncx, nrx);
 	UNPROTECT(1);
@@ -140,8 +142,8 @@ SEXP auc_SZ(SEXP THRESH, SEXP T, SEXP STIME, SEXP EVENT, SEXP N_TIME,
 		}
 	}
 
-	Free(lp_new);
-	Free(surv_new);
+	R_Free(lp_new);
+	R_Free(surv_new);
 	/* Calculation of AUC */
 	SEXP AUC;
 	PROTECT(AUC = allocVector(REALSXP, N_times));
@@ -165,9 +167,9 @@ SEXP auc_SZ(SEXP THRESH, SEXP T, SEXP STIME, SEXP EVENT, SEXP N_TIME,
 	double *f, *S, *S_new;
 	int n_new_data = INTEGER(N_TIME_NEW)[0];
 
-	f = Calloc(N_times, double);
-	S_new = Calloc(n_new_data, double);
-	S = Calloc(N_times, double);
+	f = R_Calloc(N_times, double);
+	S_new = R_Calloc(n_new_data, double);
+	S = R_Calloc(N_times, double);
 	km_Daim(S_new, REAL(STIME_NEW), REAL(EVENT_NEW), INTEGER(N_TIME_NEW));
 	step_eval2(S, REAL(T), S_new, REAL(STIME_NEW), N_times, n_new_data);
 
@@ -218,9 +220,9 @@ SEXP auc_SZ(SEXP THRESH, SEXP T, SEXP STIME, SEXP EVENT, SEXP N_TIME,
 			}
 		}
 	}
-	Free(f);
-	Free(S);
-	Free(S_new);
+	R_Free(f);
+	R_Free(S);
+	R_Free(S_new);
 
 	SEXP result, names_result;
 	PROTECT(result = allocVector(VECSXP, 5));

--- a/src/survAUC_UNO.c
+++ b/src/survAUC_UNO.c
@@ -7,6 +7,8 @@
  *
  */
 
+#define STRICT_R_HEADERS
+
 #include <Rinternals.h>
 #include <Rdefines.h>
 #include <R.h>
@@ -42,11 +44,11 @@ void auc_uno(double *auc, double *i_auc, double *sens, double *spec, double *sur
 	rsort_with_x(surv_time, status, *n_surv);
 
 	double *SProb;
-	SProb = Calloc(*n_surv, double);
+	SProb = R_Calloc(*n_surv, double);
 	km_Daim(SProb, surv_time, status, n_surv);
 
 	double *G;
-	G = Calloc(*n_new_data, double);
+	G = R_Calloc(*n_new_data, double);
 	step_eval2(G, new_surv_t, SProb, surv_time, *n_new_data, *n_surv);
 
 	for (k = 1; k < *n_th + 1; k++)
@@ -75,8 +77,8 @@ void auc_uno(double *auc, double *i_auc, double *sens, double *spec, double *sur
 			}
 		}
 	}
-	Free(SProb);
-	Free(G);
+	R_Free(SProb);
+	R_Free(G);
 	/* Calculation of specificity */
 	double Ivec_zsp, Ivec_nsp, tmp_Ivec_zsp = 0.0;
 
@@ -111,9 +113,9 @@ void auc_uno(double *auc, double *i_auc, double *sens, double *spec, double *sur
 	}
 	/* Calculation of iAUC */
 	double *f, *S, *S_new;
-	f = Calloc(*n_t, double);
-	S_new = Calloc(*n_new_data, double);
-	S = Calloc(*n_t, double);
+	f = R_Calloc(*n_t, double);
+	S_new = R_Calloc(*n_new_data, double);
+	S = R_Calloc(*n_t, double);
 	km_Daim(S_new, new_surv_t, new_event, n_new_data);
 	step_eval2(S, t, S_new, new_surv_t, *n_t, *n_new_data);
 
@@ -141,7 +143,7 @@ void auc_uno(double *auc, double *i_auc, double *sens, double *spec, double *sur
 			}
 		}
 	}
-	Free(f);
-	Free(S);
-	Free(S_new);
+	R_Free(f);
+	R_Free(S);
+	R_Free(S_new);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -7,6 +7,8 @@
  *
  */
 
+#define STRICT_R_HEADERS
+
 #include "utils.h"
 
 double dmax(double *X, int n)
@@ -432,10 +434,10 @@ SEXP survfit_cox(SEXP LP, SEXP TIME, SEXP EVENT, SEXP N_TIME, SEXP N_LP, SEXP LP
 	int i, j, k, time0;
 
 	double *lp, *time, *event, *lpnew;
-	time = Calloc(*n_time, double);
-	event = Calloc(*n_time, double);
-	lp = Calloc(*n_lp, double);
-	lpnew = Calloc(*n_lpnew, double);
+	time = R_Calloc(*n_time, double);
+	event = R_Calloc(*n_time, double);
+	lp = R_Calloc(*n_lp, double);
+	lpnew = R_Calloc(*n_lpnew, double);
 
 	for (i = 0; i < *n_lp; i++)
 	{
@@ -454,8 +456,8 @@ SEXP survfit_cox(SEXP LP, SEXP TIME, SEXP EVENT, SEXP N_TIME, SEXP N_LP, SEXP LP
 	rsort_xyz(time, event, lp, *n_time);
 
 	double *n_event, *R;
-	n_event = Calloc(*n_time, double);
-	R = Calloc(*n_time, double);
+	n_event = R_Calloc(*n_time, double);
+	R = R_Calloc(*n_time, double);
 
 	double lp_mean = 0.0;
 	lp_mean = d_mean(lp, *n_lp);
@@ -469,7 +471,7 @@ SEXP survfit_cox(SEXP LP, SEXP TIME, SEXP EVENT, SEXP N_TIME, SEXP N_LP, SEXP LP
 	my_rev_d(R, n_lp);
 
 	int *diff_time;
-	diff_time = Calloc(*n_time, int);
+	diff_time = R_Calloc(*n_time, int);
 	diff_time[0] = 1;
 
 	time0 = time[0];
@@ -494,7 +496,7 @@ SEXP survfit_cox(SEXP LP, SEXP TIME, SEXP EVENT, SEXP N_TIME, SEXP N_LP, SEXP LP
 			k++;
 		}
 	}
-	Free(diff_time);
+	R_Free(diff_time);
 	cum_sum(R, k);
 	for (i = 0, j = 0; i < k; i++)
 	{
@@ -530,11 +532,11 @@ SEXP survfit_cox(SEXP LP, SEXP TIME, SEXP EVENT, SEXP N_TIME, SEXP N_LP, SEXP LP
 	}
 	SEXP result_out = PROTECT(allocVector(VECSXP, 3));
 
-	Free(n_event);
-	Free(R);
-	Free(lp);
-	Free(time);
-	Free(event);
+	R_Free(n_event);
+	R_Free(R);
+	R_Free(lp);
+	R_Free(time);
+	R_Free(event);
 	SET_VECTOR_ELT(result_out, 0, ans);
 	SET_VECTOR_ELT(result_out, 1, utimes);
 	SET_VECTOR_ELT(result_out, 2, nevent);

--- a/src/utils.h
+++ b/src/utils.h
@@ -14,6 +14,8 @@
 #define FCONE
 #endif
 
+#include <float.h> // For FLT_EPSILON
+
 #include <R.h>
 #include <Rmath.h>
 #include <Rinternals.h>


### PR DESCRIPTION
Fixes #13 

This PR:

- Define `STRICT_R_HEADERS` in each C file.
- Use the `R_Calloc` and `R_Free` to replace `Calloc` and `Free`.
- Include `float.h` for `FLT_EPSILON`.