### PR TITLE
Release hdnom 6.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hdnom
 Type: Package
 Title: Benchmarking and Visualization Toolkit for Penalized Cox Models
-Version: 6.1.0
+Version: 6.2.0
 Authors@R: c(
     person("Nan", "Xiao", email = "me@nanx.me", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0250-5673")),

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -5,8 +5,6 @@ bibentry(
   year = "2016",
   journal = "bioRxiv",
   publisher = "Cold Spring Harbor Labs Journals",
-  URL = "https://www.biorxiv.org/content/10.1101/065524v1",
-  eprint = "https://www.biorxiv.org/content/10.1101/065524v1.full.pdf",
   textVersion = "Nan Xiao, Qing-Song Xu, and Miao-Zhu Li. (2016). hdnom: Building Nomograms for Penalized Cox Models with High-Dimensional Survival Data. bioRxiv, 065524.",
   doi = "10.1101/065524"
 )


### PR DESCRIPTION
This PR bumps the version number and removes the URLs from `inst/CITATION` as they now return HTTP 403.

News has been updated in #25.