### PR TITLE
Use `names` in `structure()` calls

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hdnom
 Type: Package
 Title: Benchmarking and Visualization Toolkit for Penalized Cox Models
-Version: 6.2.0
+Version: 6.2.1
 Authors@R: c(
     person("Nan", "Xiao", email = "me@nanx.me", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0250-5673")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# hdnom 6.2.1
+
+## Bug fixes
+
+- Updated a `structure()` call to use `names` instead of the deprecated
+  special name `.Names`, fixing an R-devel check note (#30).
+
 # hdnom 6.2.0
 
 ## Improvements

--- a/R/2_2_convert_model.R
+++ b/R/2_2_convert_model.R
@@ -71,7 +71,7 @@ convert_model <- function(model, x) {
   res$Design$assume <- rep("asis", n_nzv)
   res$Design$assume.code <- rep(1L, n_nzv)
   res$Design$parms <- list()
-  res$Design$values <- structure(list(), .Names = character(0))
+  res$Design$values <- structure(list(), names = character(0))
   res$Design$nonlinear <- vector("list", n_nzv)
   names(res$Design$nonlinear) <- names(x_nzv)
   for (i in 1L:n_nzv) res$Design$nonlinear[[i]] <- FALSE


### PR DESCRIPTION
Fixes #28 

This PR replaced `.Names` with `names` in `R/2_2_convert_model.R` to fix an r-devel check note on CRAN.